### PR TITLE
Compatible fix 2.3.x version

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -33,6 +33,13 @@ AC_DISABLE_STATIC
 # Checks for programs.
 AC_PROG_CC
 
+AC_ARG_ENABLE(devel-checks,
+AS_HELP_STRING([--enable-devel-checks], [Enable some extra expensive checks for developers]),
+	if test x$enableval = xyes; then
+		AC_DEFINE(DEBUG,, [Build with extra debugging checks])
+		want_devel_checks=yes
+	fi)
+
 # Checks for libraries.
 AC_SEARCH_LIBS([json_object_from_file], [json json-c], [], [ AC_MSG_ERROR([no json-c available]) ])
 AC_SEARCH_LIBS([json_object_object_get_ex], [json json-c], [ AC_DEFINE([JSON_HAS_GET_EX], [1], [Define if we have json_object_object_get_ex])], [])

--- a/src/fts-elastic-plugin.h
+++ b/src/fts-elastic-plugin.h
@@ -7,24 +7,29 @@
 
 #define FTS_ELASTIC_USER_CONTEXT(obj) \
     MODULE_CONTEXT(obj, fts_elastic_user_module)
+#define FTS_ELASTIC_USER_CONTEXT_REQUIRE(obj) \
+    MODULE_CONTEXT_REQUIRE(obj, fts_elastic_user_module)
 
 #ifndef i_zero
 #define i_zero(p) \
-	memset(p, 0 + COMPILE_ERROR_IF_TRUE(sizeof(p) > sizeof(void *)), sizeof(*(p)))
+    memset(p, 0 + COMPILE_ERROR_IF_TRUE(sizeof(p) > sizeof(void *)), sizeof(*(p)))
 #endif
 
-struct fts_elastic_settings {
-    const char *url;	    /* base URL to an ElasticSearch instance */
+struct fts_elastic_settings
+{
+    const char *url;        /* base URL to an ElasticSearch instance */
     const char *rawlog_dir; /* directory where raw http request and response will be saved */
     unsigned int bulk_size; /* maximum size of values indexed in _bulk requests default=5MB */
-    bool refresh_on_update;	/* if we want add ?refresh=true to elastic query*/
-    bool refresh_by_fts;	/* if we want to allow refresh http request called by fts plugin */
-    bool debug;			    /* whether or not debug is set */
+    bool refresh_on_update; /* if we want add ?refresh=true to elastic query*/
+    bool refresh_by_fts;    /* if we want to allow refresh http request called by fts plugin */
+    bool debug;             /* whether or not debug is set */
+    bool use_libfts;
 };
 
-struct fts_elastic_user {
-    union mail_user_module_context module_ctx;	/* mail user context */
-    struct fts_elastic_settings set; 		/* loaded settings */
+struct fts_elastic_user
+{
+    union mail_user_module_context module_ctx; /* mail user context */
+    struct fts_elastic_settings set;           /* loaded settings */
 };
 
 extern const char *fts_elastic_plugin_dependencies[];
@@ -37,9 +42,9 @@ void fts_elastic_plugin_deinit(void);
 
 #endif
 
-#if defined(DOVECOT_PREREQ) && DOVECOT_PREREQ(2,3)
+#if defined(DOVECOT_PREREQ) && DOVECOT_PREREQ(2, 3)
 #else
-#   define str_append_max(str, data, size) str_append_n(str, data, size);
+#define str_append_max(str, data, size) str_append_n(str, data, size);
 #endif
 
 #if !defined(FUNC_START)
@@ -50,10 +55,10 @@ void fts_elastic_plugin_deinit(void);
 #define FUNC_END_RET(ignore) ((void)0)
 #define FUNC_END_RET_INT(ignore) ((void)0)
 #else
-#define FUNC_START()		i_debug("%s:%d %s() start", __FILE__, __LINE__, __FUNCTION__)
-#define FUNC_IN()			i_debug("%s:%d %s() in", __FILE__, __LINE__, __FUNCTION__)
-#define FUNC_END()			i_debug("%s:%d %s() end", __FILE__, __LINE__, __FUNCTION__)
-#define FUNC_END_RET(r)		i_debug("%s:%d %s() return %s", __FILE__, __LINE__, __FUNCTION__, r)
-#define FUNC_END_RET_INT(r)	i_debug("%s:%d %s() return %d", __FILE__, __LINE__, __FUNCTION__, (int)r)
+#define FUNC_START() i_debug("%s:%d %s() start", __FILE__, __LINE__, __FUNCTION__)
+#define FUNC_IN() i_debug("%s:%d %s() in", __FILE__, __LINE__, __FUNCTION__)
+#define FUNC_END() i_debug("%s:%d %s() end", __FILE__, __LINE__, __FUNCTION__)
+#define FUNC_END_RET(r) i_debug("%s:%d %s() return %s", __FILE__, __LINE__, __FUNCTION__, r)
+#define FUNC_END_RET_INT(r) i_debug("%s:%d %s() return %d", __FILE__, __LINE__, __FUNCTION__, (int)r)
 #endif
 #endif


### PR DESCRIPTION
When I use the 2.3.17 version of dovecot, the core dump appears when loading the fts-elastic plugin, and the problem is found after gdb debugging
Below is the coredump information：
`Program received signal SIGSEGV, Segmentation fault.
0x00007ffff6cad2fe in fts_user_autoindex_exclude (box=box@entry=0x5555557ce198) at fts-user.c:347
347		return mailbox_match_plugin_exclude(fuser->autoindex_exclude, box);
(gdb) bt
#0  0x00007ffff6cad2fe in fts_user_autoindex_exclude (box=box@entry=0x5555557ce198) at fts-user.c:347
#1  0x00007ffff6cac402 in fts_mailbox_allocated (box=0x5555557ce198) at fts-storage.c:806
#2  0x00007ffff7aceb58 in hook_mailbox_allocated (box=box@entry=0x5555557ce198) at mail-storage-hooks.c:256
#3  0x00007ffff7ac9698 in mailbox_alloc (list=<optimized out>, vname=0x7ffff7b98a3e "INBOX", flags=flags@entry=MAILBOX_FLAG_DROP_RECENT)
    at mail-storage.c:885
#4  0x000055555556ba26 in select_open (readonly=false, mailbox=<optimized out>, ctx=0x5555557c0e68) at cmd-select.c:285
#5  cmd_select_full (cmd=<optimized out>, readonly=<optimized out>) at cmd-select.c:416
#6  0x0000555555573f04 in command_exec (cmd=0x5555557c0cc8) at imap-commands.c:201
#7  0x0000555555571de2 in client_command_input (cmd=0x5555557c0cc8) at imap-client.c:1230
#8  0x0000555555571e71 in client_command_input (cmd=0x5555557c0cc8) at imap-client.c:1297
#9  0x00005555555722f5 in client_handle_next_command (remove_io_r=<synthetic pointer>, client=0x5555557c04b8) at imap-client.c:1339
#10 client_handle_input (client=client@entry=0x5555557c04b8) at imap-client.c:1353
#11 0x00005555555728d9 in client_input (client=0x5555557c04b8) at imap-client.c:1397
#12 0x00007ffff77cc835 in io_loop_call_io (io=0x5555557b4a30) at ioloop.c:737
#13 0x00007ffff77ce1fb in io_loop_handler_run_internal (ioloop=ioloop@entry=0x55555579f030) at ioloop-epoll.c:222
#14 0x00007ffff77cc939 in io_loop_handler_run (ioloop=ioloop@entry=0x55555579f030) at ioloop.c:789
#15 0x00007ffff77ccb78 in io_loop_run (ioloop=0x55555579f030) at ioloop.c:762
#16 0x00007ffff7735203 in master_service_run (service=0x55555579ee90, callback=callback@entry=0x555555580ca0 <client_connected>) at master-service.c:863
#17 0x00005555555634d2 in main (argc=5, argv=0x55555579e780) at main.c:564`
