### PR TITLE
Provide a minimum micro version for DOVECOT_PREREQ

### DIFF
--- a/src/elastic-connection.c
+++ b/src/elastic-connection.c
@@ -85,7 +85,7 @@ int elastic_connection_init(const struct fts_elastic_settings *set,
     conn->ctx = i_new(struct elastic_search_context, 1);
     conn->ns = ns;
     conn->username = ns->owner ? ns->owner->username : "-";
-#if defined(DOVECOT_PREREQ) && DOVECOT_PREREQ(2,3)
+#if defined(DOVECOT_PREREQ) && DOVECOT_PREREQ(2,3,0)
     conn->http_host = i_strdup(http_url->host.name);
 #else
     conn->http_host = i_strdup(http_url->host_name);

--- a/src/fts-backend-elastic.c
+++ b/src/fts-backend-elastic.c
@@ -700,7 +700,7 @@ static int fts_backend_elastic_rescan(struct fts_backend *_backend)
         const char *errstr;
         box = mailbox_alloc(backend->backend.ns->list, info->vname, (enum mailbox_flags)0);
         if (mailbox_open(box) < 0) {
-#if defined(DOVECOT_PREREQ) && DOVECOT_PREREQ(2,3)
+#if defined(DOVECOT_PREREQ) && DOVECOT_PREREQ(2,3,0)
     		errstr = mailbox_get_last_internal_error(box, &error);
 #else
     		errstr = mailbox_get_last_error(box, &error);
@@ -715,7 +715,7 @@ static int fts_backend_elastic_rescan(struct fts_backend *_backend)
             continue;
         }
         if (mailbox_sync(box, (enum mailbox_sync_flags)0) < 0) {
-#if defined(DOVECOT_PREREQ) && DOVECOT_PREREQ(2,3)
+#if defined(DOVECOT_PREREQ) && DOVECOT_PREREQ(2,3,0)
     		errstr = mailbox_get_last_internal_error(box, &error);
 #else
     		errstr = mailbox_get_last_error(box, &error);

--- a/src/fts-elastic-plugin.h
+++ b/src/fts-elastic-plugin.h
@@ -39,7 +39,7 @@ void fts_elastic_plugin_deinit(void);
 
 #endif
 
-#if defined(DOVECOT_PREREQ) && DOVECOT_PREREQ(2,3)
+#if defined(DOVECOT_PREREQ) && DOVECOT_PREREQ(2,3,0)
 #else
 #   define str_append_max(str, data, size) str_append_n(str, data, size);
 #endif


### PR DESCRIPTION
Otherwise the build fails with Dovecot 2.3.18:
```
fts-elastic-plugin.h:40:50: error: macro "DOVECOT_PREREQ" requires 3
arguments, but only 2 given
   40 | #if defined(DOVECOT_PREREQ) && DOVECOT_PREREQ(2,3)
```

https://doc.dovecot.org/developer_manual/design/plugins/#versioning
> + lib: DOVECOT_PREREQ() - Add micro version which enables compiling
>   external plugins against different versions of Dovecot.

Zero is used here as the minimum micro version.

Fixes #22.