### PR TITLE
Restore compatibilty with older versions

### DIFF
--- a/src/fts-elastic-plugin.c
+++ b/src/fts-elastic-plugin.c
@@ -75,6 +75,7 @@ fts_elastic_plugin_init_settings(struct mail_user *user,
     return 0;
 }
 
+#if defined(DOVECOT_PREREQ) && DOVECOT_PREREQ(2,3,17)
 static void fts_elastic_mail_user_deinit(struct mail_user *user)
 {
     struct fts_elastic_user *fuser = FTS_ELASTIC_USER_CONTEXT_REQUIRE(user);
@@ -82,13 +83,16 @@ static void fts_elastic_mail_user_deinit(struct mail_user *user)
     fts_mail_user_deinit(user);
     fuser->module_ctx.super.deinit(user);
 }
+#endif
 
 static void fts_elastic_mail_user_create(struct mail_user *user, const char *env)
 {
     FUNC_START();
-    struct mail_user_vfuncs *v = user->vlast;
     struct fts_elastic_user *fuser = NULL;
+#if defined(DOVECOT_PREREQ) && DOVECOT_PREREQ(2,3,17)
+    struct mail_user_vfuncs *v = user->vlast;
     const char *error;
+#endif
 
     /* validate our parameters */
     if (user == NULL || env == NULL) {
@@ -102,6 +106,7 @@ static void fts_elastic_mail_user_create(struct mail_user *user, const char *env
         return;
     }
 
+#if defined(DOVECOT_PREREQ) && DOVECOT_PREREQ(2,3,17)
     if (fts_mail_user_init(user, FALSE, &error) < 0) {
         i_error("fts_elastic: %s", error);
         return;
@@ -110,6 +115,7 @@ static void fts_elastic_mail_user_create(struct mail_user *user, const char *env
     fuser->module_ctx.super = *v;
     user->vlast = &fuser->module_ctx.super;
     v->deinit = fts_elastic_mail_user_deinit;
+#endif
 
     MODULE_CONTEXT_SET(user, fts_elastic_user_module, fuser);
     FUNC_END();

--- a/src/fts-elastic-plugin.h
+++ b/src/fts-elastic-plugin.h
@@ -39,6 +39,14 @@ void fts_elastic_plugin_deinit(void);
 
 #endif
 
+#if ((DOVECOT_VERSION_MAJOR << 24) + (DOVECOT_VERSION_MINOR << 16) + DOVECOT_VERSION_MICRO < ((2) << 24) + ((3) << 16) + (18))
+#undef DOVECOT_PREREQ
+#define DOVECOT_PREREQ(maj, min, micro) \
+       ((DOVECOT_VERSION_MAJOR << 24) + \
+        (DOVECOT_VERSION_MINOR << 16) + \
+        DOVECOT_VERSION_MICRO >= ((maj) << 24) + ((min) << 16) + (micro))
+#endif
+
 #if defined(DOVECOT_PREREQ) && DOVECOT_PREREQ(2,3,0)
 #else
 #   define str_append_max(str, data, size) str_append_n(str, data, size);


### PR DESCRIPTION
Closes: #26
Closes: #27

Checked to compile with 2.2.36 (and run) and 2.3.16/2.3.20 (compile only).