### PR TITLE
Fix header include order

### DIFF
--- a/src/fts-elastic-plugin.c
+++ b/src/fts-elastic-plugin.c
@@ -5,9 +5,9 @@
 #include "lib.h"
 #include "array.h"
 #include "http-client.h"
-#include "fts-user.h"
 #include "mail-user.h"
 #include "mail-storage-hooks.h"
+#include "fts-user.h"
 #include "fts-elastic-plugin.h"
 
 #include <stdlib.h>


### PR DESCRIPTION
Without this I'm getting the following error building using GCC 14.2.1.  Presumably this was always broken and just happened to work because earlier compilers were more lenient.

<details>
<summary>Error log</summary>

```text
In file included from fts-elastic-plugin.c:8:
/usr/include/dovecot/fts-user.h:12:31: warning: 'struct mail_user' declared inside parameter list will not be visible outside of this definition or declaration
   12 | fts_user_language_find(struct mail_user *user,
      |                               ^~~~~~~~~
/usr/include/dovecot/fts-user.h:14:61: warning: 'struct mail_user' declared inside parameter list will not be visible outside of this definition or declaration
   14 | struct fts_language_list *fts_user_get_language_list(struct mail_user *user);
      |                                                             ^~~~~~~~~
/usr/include/dovecot/fts-user.h:16:35: warning: 'struct mail_user' declared inside parameter list will not be visible outside of this definition or declaration
   16 | fts_user_get_all_languages(struct mail_user *user);
      |                                   ^~~~~~~~~
/usr/include/dovecot/fts-user.h:17:57: warning: 'struct mail_user' declared inside parameter list will not be visible outside of this definition or declaration
   17 | struct fts_user_language *fts_user_get_data_lang(struct mail_user *user);
      |                                                         ^~~~~~~~~
/usr/include/dovecot/fts-user.h:19:40: warning: 'struct mailbox' declared inside parameter list will not be visible outside of this definition or declaration
   19 | bool fts_user_autoindex_exclude(struct mailbox *box);
      |                                        ^~~~~~~
/usr/include/dovecot/fts-user.h:21:31: warning: 'struct mail_user' declared inside parameter list will not be visible outside of this definition or declaration
   21 | int fts_mail_user_init(struct mail_user *user, bool initialize_libfts,
      |                               ^~~~~~~~~
/usr/include/dovecot/fts-user.h:23:34: warning: 'struct mail_user' declared inside parameter list will not be visible outside of this definition or declaration
   23 | void fts_mail_user_deinit(struct mail_user *user);
      |                                  ^~~~~~~~~
fts-elastic-plugin.c: In function 'fts_elastic_mail_user_deinit':
fts-elastic-plugin.c:82:26: error: passing argument 1 of 'fts_mail_user_deinit' from incompatible pointer type [-Wincompatible-pointer-types]
   82 |     fts_mail_user_deinit(user);
      |                          ^~~~
      |                          |
      |                          struct mail_user *
/usr/include/dovecot/fts-user.h:23:45: note: expected 'struct mail_user *' but argument is of type 'struct mail_user *'
   23 | void fts_mail_user_deinit(struct mail_user *user);
      |                           ~~~~~~~~~~~~~~~~~~^~~~
fts-elastic-plugin.c: In function 'fts_elastic_mail_user_create':
fts-elastic-plugin.c:105:28: error: passing argument 1 of 'fts_mail_user_init' from incompatible pointer type [-Wincompatible-pointer-types]
  105 |     if (fts_mail_user_init(user, FALSE, &error) < 0) {
      |                            ^~~~
      |                            |
      |                            struct mail_user *
/usr/include/dovecot/fts-user.h:21:42: note: expected 'struct mail_user *' but argument is of type 'struct mail_user *'
   21 | int fts_mail_user_init(struct mail_user *user, bool initialize_libfts,
      |                        ~~~~~~~~~~~~~~~~~~^~~~
make[2]: *** [Makefile:478: fts-elastic-plugin.lo] Error 1
```
</details>